### PR TITLE
Add Serenity Test

### DIFF
--- a/MenuApiTSIntegrationTests/MenuApiTSIntegrationTests.njsproj
+++ b/MenuApiTSIntegrationTests/MenuApiTSIntegrationTests.njsproj
@@ -38,10 +38,14 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="features\" />
+    <Folder Include="features\support\" />
     <Folder Include="features\step_definitions\" />
   </ItemGroup>
   <ItemGroup>
     <TypeScriptCompile Include="features\step_definitions\stepdefs.ts">
+      <SubType>Code</SubType>
+    </TypeScriptCompile>
+    <TypeScriptCompile Include="features\support\serenity.config.ts">
       <SubType>Code</SubType>
     </TypeScriptCompile>
   </ItemGroup>

--- a/MenuApiTSIntegrationTests/features/getMenu.feature
+++ b/MenuApiTSIntegrationTests/features/getMenu.feature
@@ -2,4 +2,4 @@ Feature: What's the menu?
     Everybody wants to know the restaurant's menu
     
     Scenario: Get the Menu
-        Given the menu is available
+        Given the playwright menu is available

--- a/MenuApiTSIntegrationTests/features/step_definitions/stepdefs.ts
+++ b/MenuApiTSIntegrationTests/features/step_definitions/stepdefs.ts
@@ -1,5 +1,10 @@
 import { Given, Then, When } from '@cucumber/cucumber';
 import { spec } from 'pactum';
+import { Ensure, equals } from '@serenity-js/assertions'
+import { actorCalled, Cast, engage } from '@serenity-js/core'
+import { CallAnApi, GetRequest, LastResponse, Send } from '@serenity-js/rest'
+
+const baseURL = 'https://localhost:7235/api/Menu/'
 
 Given('the menu is available', async function () {
     // Write code here that turns the phrase above into concrete actions
@@ -23,4 +28,19 @@ Given('the menu is available', async function () {
                 }
             ]
         });
+});
+
+Given('the playwright menu is available', async function () {
+    // Write code here that turns the phrase above into concrete actions
+    // return 'pending';
+   
+        engage(Cast.where(actor =>
+            actor.whoCan(CallAnApi.at(baseURL)))                  // 1) Add ability
+        )
+    
+
+    await actorCalled('Apisitt').attemptsTo(
+        Send.a(GetRequest.to('1')),             // 2) Send request
+        Ensure.that(LastResponse.status(), equals(200)),  // 3) Verify response
+    )
 });

--- a/MenuApiTSIntegrationTests/features/support/serenity.config.ts
+++ b/MenuApiTSIntegrationTests/features/support/serenity.config.ts
@@ -1,0 +1,35 @@
+import { BeforeAll, AfterAll } from '@cucumber/cucumber'
+import { configure, Cast } from '@serenity-js/core'
+import { CallAnApi} from '@serenity-js/rest'
+import { BrowseTheWebWithPlaywright } from '@serenity-js/playwright'
+
+import * as playwright from 'playwright'
+
+let browser: playwright.Browser;
+
+BeforeAll(async () => {
+
+    // Launch the browser once before all the tests
+    // Serenity/JS will take care of managing Playwright browser context and browser tabs.
+    browser = await playwright.chromium.launch({
+        headless: true,
+    });
+
+    // Configure Serenity/JS
+    configure({
+        actors: Cast.where(actor =>
+            actor.whoCan(CallAnApi.at('https://localhost:7235/api/Menu/'))
+        ),
+        crew: [
+            '@serenity-js/console-reporter',
+            '@serenity-js/serenity-bdd',
+            ['@serenity-js/core:ArtifactArchiver', { outputDirectory: 'target/site/serenity' }],
+            // ... any other reporting services
+        ],
+    })
+})
+
+AfterAll(async () => {
+    // Close the browser after all the tests are finished
+    await browser?.close()
+})

--- a/MenuApiTSIntegrationTests/package-lock.json
+++ b/MenuApiTSIntegrationTests/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "^16.4.5",
         "eslint": "^8.21.0",
         "pactum": "^3.6.8",
+        "playwright": "^1.44.0",
         "typescript": "^4.5.2"
       }
     },
@@ -1624,6 +1625,20 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -2506,6 +2521,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.0.tgz",
+      "integrity": "sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.44.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
+      "integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/polka": {

--- a/MenuApiTSIntegrationTests/package-lock.json
+++ b/MenuApiTSIntegrationTests/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "menu-api-tsintegration-tests",
       "version": "0.0.0",
+      "dependencies": {
+        "ts-node": "^10.9.2"
+      },
       "devDependencies": {
         "@cucumber/cucumber": "^10.7.0",
         "@serenity-js/assertions": "^3.23.0",
@@ -15,14 +18,14 @@
         "@serenity-js/cucumber": "^3.23.0",
         "@serenity-js/rest": "^3.23.0",
         "@serenity-js/serenity-bdd": "^3.23.0",
-        "@types/node": "^14.14.7",
+        "@types/node": "^14.18.63",
         "@typescript-eslint/eslint-plugin": "^5.33.0",
         "@typescript-eslint/parser": "^5.33.0",
         "dotenv": "^16.4.5",
         "eslint": "^8.21.0",
         "pactum": "^3.6.8",
         "playwright": "^1.44.0",
-        "typescript": "^4.5.2"
+        "typescript": "^4.9.5"
       }
     },
     "node_modules/@arr/every": {
@@ -150,6 +153,17 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@cucumber/ci-environment": {
@@ -584,6 +598,28 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
@@ -852,6 +888,26 @@
         "node": ">=14"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw=="
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -861,8 +917,7 @@
     "node_modules/@types/node": {
       "version": "14.18.63",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "dev": true
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -1080,7 +1135,6 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1095,6 +1149,14 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -1154,6 +1216,11 @@
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1380,6 +1447,11 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1436,7 +1508,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -2520,6 +2591,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node_modules/matchit": {
       "version": "1.1.0",
@@ -3610,6 +3686,48 @@
         "node": ">=6"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -3659,7 +3777,6 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3720,6 +3837,11 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -3934,6 +4056,14 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/MenuApiTSIntegrationTests/package-lock.json
+++ b/MenuApiTSIntegrationTests/package-lock.json
@@ -9,6 +9,11 @@
       "version": "0.0.0",
       "devDependencies": {
         "@cucumber/cucumber": "^10.7.0",
+        "@serenity-js/assertions": "^3.23.0",
+        "@serenity-js/console-reporter": "^3.23.0",
+        "@serenity-js/core": "^3.23.0",
+        "@serenity-js/rest": "^3.23.0",
+        "@serenity-js/serenity-bdd": "^3.23.0",
         "@types/node": "^14.14.7",
         "@typescript-eslint/eslint-plugin": "^5.33.0",
         "@typescript-eslint/parser": "^5.33.0",
@@ -578,6 +583,18 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -613,6 +630,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -628,6 +654,147 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-0.5.0.tgz",
       "integrity": "sha512-oZLYFEAzUKyi3SKnXvj32ZCEGH6RDnao7COuCVhDydMS9NrCSVXhM79VaKyP5+Zc33m0QXEd2DN3UkU7OsHcfw==",
       "dev": true
+    },
+    "node_modules/@serenity-js/assertions": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@serenity-js/assertions/-/assertions-3.23.0.tgz",
+      "integrity": "sha512-fOgTiU3mSWJTr5QoM4soIMo1UECz32XHY8Grt28d/5fE5Nc8siSdKnEIsXCI9u2z0Whu6layWjoLrLKAfkAx0g==",
+      "dev": true,
+      "dependencies": {
+        "@serenity-js/core": "3.23.0",
+        "tiny-types": "1.22.0"
+      },
+      "engines": {
+        "node": "^16.13 || ^18.12 || ^20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/serenity-js"
+      }
+    },
+    "node_modules/@serenity-js/console-reporter": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@serenity-js/console-reporter/-/console-reporter-3.23.0.tgz",
+      "integrity": "sha512-6L2aGYTvsBB8pw8EyzTVF23zbQwpAtXPqSvj9BIlCT0UFqOtLjliojEf8jV+iFv0e5IuxZif1yvrE7YCFFrQDA==",
+      "dev": true,
+      "dependencies": {
+        "@serenity-js/core": "3.23.0",
+        "chalk": "4.1.2",
+        "tiny-types": "1.22.0"
+      },
+      "engines": {
+        "node": "^16.13 || ^18.12 || ^20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/serenity-js"
+      }
+    },
+    "node_modules/@serenity-js/core": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@serenity-js/core/-/core-3.23.0.tgz",
+      "integrity": "sha512-8KA0aZkznfrZgn5pwKn0cpcHgDg60DIQmk/Ft5EsHxRsGiAs6t6/UAeXSK2KghbYN8I4O0bHp06AtdTtD1BRkA==",
+      "dev": true,
+      "dependencies": {
+        "@paralleldrive/cuid2": "2.2.2",
+        "chalk": "4.1.2",
+        "diff": "5.2.0",
+        "error-stack-parser": "2.1.4",
+        "fast-glob": "3.3.2",
+        "filenamify": "4.3.0",
+        "graceful-fs": "4.2.11",
+        "semver": "7.6.2",
+        "tiny-types": "1.22.0",
+        "upath": "2.0.1",
+        "validate-npm-package-name": "5.0.1"
+      },
+      "engines": {
+        "node": "^16.13 || ^18.12 || ^20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/serenity-js"
+      }
+    },
+    "node_modules/@serenity-js/core/node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@serenity-js/rest": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@serenity-js/rest/-/rest-3.23.0.tgz",
+      "integrity": "sha512-xGZ5Tj4ZQjOeocmYeC4tjXu4WBWpqCQSp0eZEWqwx43OvU6KTD+7wnduO9uZCodCN1eQoTc3Yly7Ag+R6yKY9A==",
+      "dev": true,
+      "dependencies": {
+        "@serenity-js/core": "3.23.0",
+        "agent-base": "7.1.1",
+        "axios": "1.6.8",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.4",
+        "lru-cache": "10.2.2",
+        "proxy-from-env": "1.1.0",
+        "tiny-types": "1.22.0"
+      },
+      "engines": {
+        "node": "^16.13 || ^18.12 || ^20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/serenity-js"
+      }
+    },
+    "node_modules/@serenity-js/serenity-bdd": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@serenity-js/serenity-bdd/-/serenity-bdd-3.23.0.tgz",
+      "integrity": "sha512-LJhrHHyRy77igb8/Uf/pZCB3Kj68BqapGz+t78Ujjr/VulIjetm4NtJHinxbCT6aomhIDggP+qa+3yAs0rLe4g==",
+      "dev": true,
+      "dependencies": {
+        "@serenity-js/assertions": "3.23.0",
+        "@serenity-js/core": "3.23.0",
+        "@serenity-js/rest": "3.23.0",
+        "ansi-regex": "5.0.1",
+        "axios": "1.6.8",
+        "chalk": "4.1.2",
+        "find-java-home": "2.0.0",
+        "progress": "2.0.3",
+        "tiny-types": "1.22.0",
+        "which": "4.0.0",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "serenity-bdd": "bin/serenity-bdd"
+      },
+      "engines": {
+        "node": "^16.13 || ^18.12 || ^20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/serenity-js"
+      }
+    },
+    "node_modules/@serenity-js/serenity-bdd/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@serenity-js/serenity-bdd/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/@teppeis/multimaps": {
       "version": "3.0.0",
@@ -883,6 +1050,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -960,6 +1139,17 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
+    },
+    "node_modules/axios": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1065,6 +1255,37 @@
       },
       "optionalDependencies": {
         "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/color-convert": {
@@ -1237,6 +1458,15 @@
       "dev": true,
       "dependencies": {
         "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1524,6 +1754,32 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/filename-reserved-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+      "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+      "dev": true,
+      "dependencies": {
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.1",
+        "trim-repeated": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -1534,6 +1790,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/find-java-home": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-java-home/-/find-java-home-2.0.0.tgz",
+      "integrity": "sha512-m4Cf5WM5Y9UupofsLgcJuY5oFXVfVnfHx43pg3HJoVdtY2PN4Wfs7ex9svf7W7eLTP+6wmyBToaqGOCffHBHVA==",
+      "dev": true,
+      "dependencies": {
+        "which": "~1.0.5",
+        "winreg": "~1.2.2"
+      }
+    },
+    "node_modules/find-java-home/node_modules/which": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+      "integrity": "sha512-E87fdQ/eRJr9W1X4wTPejNy9zTW3FI2vpCZSJ/HAY+TkjKVC0TUm1jk6vn2Z7qay0DQy0+RBGdXxj+RmmiGZKQ==",
+      "dev": true,
+      "bin": {
+        "which": "bin/which"
       }
     },
     "node_modules/find-up": {
@@ -1608,6 +1883,20 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/form-data-lite": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/form-data-lite/-/form-data-lite-1.0.3.tgz",
@@ -1646,6 +1935,15 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/glob": {
@@ -1730,6 +2028,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -1783,6 +2087,32 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.1",
@@ -2168,11 +2498,32 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mime-lite": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/mime-lite/-/mime-lite-1.0.3.tgz",
       "integrity": "sha512-V85l97zJSTG8FEvmdTlmNYb0UMrVBwvRjw7bWTf/aT6KjFwtz3iTz8D2tuFIp7lwiaO2C5ecnrEmSkkMRCrqVw==",
       "dev": true
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -2587,6 +2938,12 @@
       "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
       "dev": true
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2750,6 +3107,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -3039,6 +3405,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-outer/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3096,6 +3483,16 @@
       "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
       "dev": true
     },
+    "node_modules/tiny-types": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/tiny-types/-/tiny-types-1.22.0.tgz",
+      "integrity": "sha512-NQZpeRLP+jbw1iZ/PCNDmAWmm5anY6WpDTQeVfFbu7dmumLQLkcvBFTpBXLwChFp1/U+Mv0DF51KelSIvHP2FA==",
+      "dev": true,
+      "engines": {
+        "node": "^16 || ^18 || ^20",
+        "npm": "^8 || ^9 || ^10"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
@@ -3122,6 +3519,27 @@
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
       "dev": true
+    },
+    "node_modules/trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/trim-repeated/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/trouter": {
       "version": "2.0.1",
@@ -3193,6 +3611,16 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/upath": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
+      "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
+      "dev": true,
+      "engines": {
+        "node": ">=4",
+        "yarn": "*"
+      }
+    },
     "node_modules/upper-case-first": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
@@ -3246,6 +3674,15 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/validate-npm-package-name": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
+      "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3260,6 +3697,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/winreg": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.5.tgz",
+      "integrity": "sha512-uf7tHf+tw0B1y+x+mKTLHkykBgK2KMs3g+KlzmyMbLvICSHQyB/xOFjTT8qZ3oeTFyU7Bbj4FzXitGG6jvKhYw==",
+      "dev": true
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
@@ -3382,6 +3825,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -3398,6 +3850,33 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/MenuApiTSIntegrationTests/package-lock.json
+++ b/MenuApiTSIntegrationTests/package-lock.json
@@ -12,6 +12,7 @@
         "@serenity-js/assertions": "^3.23.0",
         "@serenity-js/console-reporter": "^3.23.0",
         "@serenity-js/core": "^3.23.0",
+        "@serenity-js/cucumber": "^3.23.0",
         "@serenity-js/rest": "^3.23.0",
         "@serenity-js/serenity-bdd": "^3.23.0",
         "@types/node": "^14.14.7",
@@ -720,6 +721,52 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@serenity-js/cucumber": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@serenity-js/cucumber/-/cucumber-3.23.0.tgz",
+      "integrity": "sha512-9b3y1br2joPEQFCJN1oS99e6xwE80RVYbidM2X3Ae2/aCQnRTfFPqg5m+0RjhYxCBuai8CKQ6uXqEVlmQZxPag==",
+      "dev": true,
+      "dependencies": {
+        "@cucumber/messages": "24.1.0",
+        "@serenity-js/core": "3.23.0",
+        "cli-table3": "0.6.4",
+        "gherkin": "5.1.0",
+        "tiny-types": "1.22.0"
+      },
+      "engines": {
+        "node": "^16.13 || ^18.12 || ^20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/serenity-js"
+      },
+      "peerDependencies": {
+        "@cucumber/cucumber": "^7.3.2 || ^8.5.0 || ^9.1.0 || ^10.0.0",
+        "cucumber": "^1.3.3 || ^2.3.1 || ^3.2.1 || ^4.2.1 || ^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@cucumber/cucumber": {
+          "optional": true
+        },
+        "cucumber": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@serenity-js/cucumber/node_modules/cli-table3": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.4.tgz",
+      "integrity": "sha512-Lm3L0p+/npIQWNIiyF/nAn7T5dnOwR3xNTHXYEBFBFVPXzCVNZ5lqEC/1eo/EVfpDsQ1I+TX4ORPQgp+UI0CRw==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
       }
     },
     "node_modules/@serenity-js/rest": {
@@ -1944,6 +1991,16 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/gherkin": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/gherkin/-/gherkin-5.1.0.tgz",
+      "integrity": "sha512-axTCsxH0m0cixijLvo7s9591h5pMb8ifQxFDun5FnfFhVsUhxgdnH0H7TSK7q8I4ASUU18DJ/tmlnMegMuLUUQ==",
+      "deprecated": "This package is now published under @cucumber/gherkin",
+      "dev": true,
+      "bin": {
+        "gherkin-javascript": "bin/gherkin"
       }
     },
     "node_modules/glob": {

--- a/MenuApiTSIntegrationTests/package.json
+++ b/MenuApiTSIntegrationTests/package.json
@@ -19,6 +19,7 @@
     "dotenv": "^16.4.5",
     "eslint": "^8.21.0",
     "pactum": "^3.6.8",
+    "playwright": "^1.44.0",
     "typescript": "^4.5.2"
   },
   "eslintConfig": {

--- a/MenuApiTSIntegrationTests/package.json
+++ b/MenuApiTSIntegrationTests/package.json
@@ -13,6 +13,11 @@
   },
   "devDependencies": {
     "@cucumber/cucumber": "^10.7.0",
+    "@serenity-js/assertions": "^3.23.0",
+    "@serenity-js/console-reporter": "^3.23.0",
+    "@serenity-js/core": "^3.23.0",
+    "@serenity-js/rest": "^3.23.0",
+    "@serenity-js/serenity-bdd": "^3.23.0",
     "@types/node": "^14.14.7",
     "@typescript-eslint/eslint-plugin": "^5.33.0",
     "@typescript-eslint/parser": "^5.33.0",

--- a/MenuApiTSIntegrationTests/package.json
+++ b/MenuApiTSIntegrationTests/package.json
@@ -16,6 +16,7 @@
     "@serenity-js/assertions": "^3.23.0",
     "@serenity-js/console-reporter": "^3.23.0",
     "@serenity-js/core": "^3.23.0",
+    "@serenity-js/cucumber": "^3.23.0",
     "@serenity-js/rest": "^3.23.0",
     "@serenity-js/serenity-bdd": "^3.23.0",
     "@types/node": "^14.14.7",

--- a/MenuApiTSIntegrationTests/package.json
+++ b/MenuApiTSIntegrationTests/package.json
@@ -19,14 +19,14 @@
     "@serenity-js/cucumber": "^3.23.0",
     "@serenity-js/rest": "^3.23.0",
     "@serenity-js/serenity-bdd": "^3.23.0",
-    "@types/node": "^14.14.7",
+    "@types/node": "^14.18.63",
     "@typescript-eslint/eslint-plugin": "^5.33.0",
     "@typescript-eslint/parser": "^5.33.0",
     "dotenv": "^16.4.5",
     "eslint": "^8.21.0",
     "pactum": "^3.6.8",
     "playwright": "^1.44.0",
-    "typescript": "^4.5.2"
+    "typescript": "^4.9.5"
   },
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",
@@ -37,5 +37,8 @@
     "plugins": [
       "@typescript-eslint"
     ]
+  },
+  "dependencies": {
+    "ts-node": "^10.9.2"
   }
 }

--- a/MenuApiTSIntegrationTests/tsconfig.json
+++ b/MenuApiTSIntegrationTests/tsconfig.json
@@ -5,7 +5,8 @@
     "lib": [ "es6", "dom" ],
     "sourceMap": true,
     "outDir": "./dist",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
Installed Playwright and Serenity. Cloned the existing Typescript cucumber test, and converted it to a Serenity test. Was having some errors with the Serenity typescript file referring to a "BufferedEncoding" type from the NodeJS namespace (which is global.d.ts), and it was complaining that it was not exported. So I added skipLibCheck = true to the tsconfig. 

Pretty sure my Serenity configuration isn't correct as I had to setup the "Actor who can call an API" directly in the test after I'd already set it up in the serenity config file. But it's working, so checking it in for now. 